### PR TITLE
Fix php 8 errors

### DIFF
--- a/tests/acceptance/FrontendTest.php
+++ b/tests/acceptance/FrontendTest.php
@@ -14,7 +14,7 @@ class FrontendTest extends oxAcceptanceTestCase
     /**
      * Adds configuration data for testing
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $aConfigData = $this->getAmazonPaySettings();

--- a/tests/phpunitextensions.php
+++ b/tests/phpunitextensions.php
@@ -27,7 +27,7 @@ class MatchIgnoreWhitespace extends PHPUnitContraintParent
         $this->exporter = new Exporter();
     }
 
-    protected function matches($actual)
+    protected function matches($actual): bool
     {
         return $this->normalize($this->expected) == $this->normalize($actual);
     }


### PR DESCRIPTION
With the required changes for PHP 8 we have some errors that need to be handled.

Amazonpay:
```
Fatal error: Declaration of MatchIgnoreWhitespace::matches($actual) must be compatible with PHPUnit\Framework\Constraint\Constraint::matches($other): bool in /var/www/oxideshop/source/modules/bestit/amazonpay4oxid/tests/phpunitextensions.php on line 30

Fatal error: Declaration of FrontendTest::setUp() must be compatible with OxidEsales\TestingLibrary\AcceptanceTestCase::setUp(): void in /var/www/oxideshop/source/modules/bestit/amazonpay4oxid/tests/acceptance/FrontendTest.php on line 17
```